### PR TITLE
change default auth method for documentation on developer.bcc.no to bcc-login

### DIFF
--- a/.github/workflows/publish-decision-records.yml
+++ b/.github/workflows/publish-decision-records.yml
@@ -27,3 +27,4 @@ jobs:
           auto-register-components: true
           components-dir: components
           branch: main
+          authentication: 'portal'


### PR DESCRIPTION
change default auth method for documentation on developer.bcc.no to bcc-login